### PR TITLE
Add etoolbox into required packages, required for \ifstrempty

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 LPPL License 1.3c
 
-Copyright (C) 2019-2024 Leo C. Stein <leo.stein@gmail.com>
+Copyright (C) 2019-2026 Leo C. Stein <leo.stein@gmail.com>
 
 This work may be distributed and/or modified under the
 conditions of the LaTeX Project Public License, either version 1.3

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ Credits
 The original TikZ icon code was created by user [Milo on
 TeX.SE](https://tex.stackexchange.com/users/128068/milo).
 This package was created and is maintained by [Leo
-C. Stein](http://duetosymmetry.com/), (c) 2019-2024.
+C. Stein](http://duetosymmetry.com/), (c) 2019-2026.
 This material is subject to the [LaTeX Project Public License
 1.3c](https://www.ctan.org/license/lppl1.3).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Dependancies and Compatibility
 ------------------------------
 
 This package relies on the following packages:
+- [etoolbox](https://ctan.org/pkg/etoolbox) (depending on hyperref>=2023-04-20
+  already relies on etoolbox)
 - [hyperref](https://www.ctan.org/pkg/hyperref)
 - [tikz](https://www.ctan.org/pkg/pgf)
 

--- a/orcidlink.dtx
+++ b/orcidlink.dtx
@@ -75,7 +75,8 @@
 % \changes{v1.1.0}{2024/06/25}{Support ORCID's three different ID
 % formats. Thanks to Hugo Heagren for suggestions.}
 % \changes{v1.1.1}{2026/04/09}{Add explicit dependency for etoolbox. Solves
-% potential errors if etoolbox isn't properly pulled in from hyperref.}
+% potential errors if etoolbox isn't properly pulled in from hyperref. Thanks to
+% Otto Hanski.}
 %
 % \DoNotIndex{\newcommand,\newenvironment}
 %

--- a/orcidlink.dtx
+++ b/orcidlink.dtx
@@ -1,6 +1,6 @@
 % \iffalse meta-comment
 %
-% Copyright (C) 2019-2024 by Leo C. Stein <leo.stein@gmail.com>
+% Copyright (C) 2019-2026 by Leo C. Stein <leo.stein@gmail.com>
 % ---------------------------------------------------------------------------
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either version 1.3
@@ -27,7 +27,7 @@
 %<*driver>
 \documentclass{ltxdoc}
 \usepackage[dvipsnames]{xcolor}
-\usepackage{orcidlink}[2024/06/25]
+\usepackage{orcidlink}[2024/04/09]
 \hypersetup{colorlinks,urlcolor=NavyBlue,citecolor=NavyBlue,linkcolor=NavyBlue}
 \hypersetup{pdftitle={The orcidlink package},pdfauthor={Leo C. Stein},
   pdfsubject={-}}
@@ -43,7 +43,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{59}
+% \CheckSum{60}
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -74,6 +74,8 @@
 % Thanks to github user aquileia for the bug report.}
 % \changes{v1.1.0}{2024/06/25}{Support ORCID's three different ID
 % formats. Thanks to Hugo Heagren for suggestions.}
+% \changes{v1.1.1}{2026/04/09}{Add explicit dependency for etoolbox. Solves
+% potential errors if etoolbox isn't properly pulled in from hyperref.}
 %
 % \DoNotIndex{\newcommand,\newenvironment}
 %
@@ -169,11 +171,12 @@
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesPackage{orcidlink}
-    [2024/06/26 v1.1.0 Support ORCID's three different ID formats.]
+    [2026/04/09 v1.1.1 Add explicit etoolbox dependency.]
 
 %% This started out as Milo's code on TeX.SE,
 %% see https://tex.stackexchange.com/a/445583/34063.
 %% It has since been expanded with more commands.
+\RequirePackage{etoolbox}
 \RequirePackage{hyperref}
 \RequirePackage{tikz}
 

--- a/orcidlink.ins
+++ b/orcidlink.ins
@@ -1,4 +1,4 @@
-%% Copyright (C) 2019-2024 by Leo C. Stein <leo.stein@gmail.com>
+%% Copyright (C) 2019-2026 by Leo C. Stein <leo.stein@gmail.com>
 %% --------------------------------------------------------------------------
 %% This work may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3
@@ -25,7 +25,7 @@
 
 This is a generated file.
 
-Copyright (C) 2019-2024 by Leo C. Stein <leo.stein@gmail.com>
+Copyright (C) 2019-2026 by Leo C. Stein <leo.stein@gmail.com>
 --------------------------------------------------------------------------
 This work may be distributed and/or modified under the
 conditions of the LaTeX Project Public License, either version 1.3

--- a/orcidlink.sty
+++ b/orcidlink.sty
@@ -8,7 +8,7 @@
 %% 
 %% This is a generated file.
 %% 
-%% Copyright (C) 2019-2024 by Leo C. Stein <leo.stein@gmail.com>
+%% Copyright (C) 2019-2026 by Leo C. Stein <leo.stein@gmail.com>
 %% --------------------------------------------------------------------------
 %% This work may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3

--- a/orcidlink.sty
+++ b/orcidlink.sty
@@ -20,11 +20,12 @@
 %% 
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesPackage{orcidlink}
-    [2024/06/26 v1.1.0 Support ORCID's three different ID formats.]
+    [2026/04/09 v1.1.1 Add explicit etoolbox dependency.]
 
 %% This started out as Milo's code on TeX.SE,
 %% see https://tex.stackexchange.com/a/445583/34063.
 %% It has since been expanded with more commands.
+\RequirePackage{etoolbox}
 \RequirePackage{hyperref}
 \RequirePackage{tikz}
 


### PR DESCRIPTION
Heyo, just added a missing dependency, which has annoyed me on several occasions.